### PR TITLE
feat: Add support with docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:10
+
+ENV RELEASE_VERSION=3.9.3
+
+# Create app directory
+WORKDIR /opt/Apps
+
+# Copy project files
+RUN wget -c https://github.com/adempiere/adempiere-vue/archive/v$RELEASE_VERSION.tar.gz
+
+# uncompress and delete files
+RUN tar -zxvf v$RELEASE_VERSION.tar.gz \
+&& rm v$RELEASE_VERSION.tar.gz \
+&& mv adempiere-vue-$RELEASE_VERSION adempiere-vue
+
+WORKDIR /opt/Apps/adempiere-vue
+
+# TODO: Generate releases with versions that include libraries and compiled files ready for production
+# Install app dependencies
+RUN npm install
+# RUN npm run build:prod
+
+EXPOSE 9526 9527
+
+# CMD npm run preview
+CMD npm run dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: '3.7'
+
+services:
+  web-client:
+    container_name: adempiere-ui-client
+    network_mode: bridge
+    build: .
+    volumes:
+      - /usr/app/
+      - /usr/app/node_modules
+    labels:
+      - app=adempiere-vue
+      - maintainer=EdwinBetanc0urt@outlook.com
+    stdin_open: true
+    tty: true
+    environment:
+      - VUE_APP_PROXY_ADDRESS=20.12.0.105
+      - VUE_APP_PROXY_PORT=8989
+    # TODO: Add enviroment variables to ports
+    ports:
+      - 9526:9526 # Prod
+      - 9527:9527 # Dev


### PR DESCRIPTION
Added support with docker-compose for adempiere-vue

Download the release with the version set in the environment variable RELEASE_VERSION, install the dependencies and libraries, and run an instance on port 9727.

TODO: Generate releases with versions that include libraries and compiled files ready for production